### PR TITLE
fix tags working on View and Run actions

### DIFF
--- a/CronController.php
+++ b/CronController.php
@@ -189,7 +189,7 @@ RAW;
     public function actionRun(array $args = [])
     {
 
-        $tags = array_unique(array_merge($args, $this->defaultConfig['tags']));
+        $tags = $args ? $args : $this->defaultConfig['tags'];
 
         $time = strtotime($this->timestamp);
         $actions = $this->prepareActionsToRun($tags);
@@ -258,7 +258,7 @@ RAW;
      */
     public function actionView(array $args = [])
     {
-        $tags = array_unique(array_merge($args, $this->defaultConfig['tags']));
+        $tags = $args ? $args : $this->defaultConfig['tags'];
 
         foreach ($this->prepareActions() as $task) {
             if (!$tags || array_intersect($tags, $task['tags'])) {


### PR DESCRIPTION
fix "cron/view tagname" and "cron/run tagname" triggering all commands (should show/run command only with selected tag)