### PR TITLE
Allow to change default config for cronJobs

### DIFF
--- a/CronController.php
+++ b/CronController.php
@@ -53,7 +53,10 @@ class CronController extends Controller
      */
     public $defaultAction = 'run';
 
-    protected $defaultConfig = [
+    /**
+     * @var array default config for cron jobs
+     */
+    public $defaultConfig = [
         'timing' => [
             'min' => '*',
             'hour' => '*',


### PR DESCRIPTION
Suddenly cron jobs with default options don’t run on production (YII_ENV_PROD) without any Exception because superAdminIntegration defaults TRUE

Also superAdminIntegration don't described at README.md

Firstly superAdminIntegration default value should be able to change from TRUE to FALSE.
As fast solution I suggest to change 'protected $defaultConfig' to 'public $defaultConfig'.

After that it will be better to describe  superAdminIntegration functional at README.md and maybe add some Exception so it was clearly why cron/run work fine on DEV and do nothing on production.